### PR TITLE
Fix a bug about the wrong serializedName of Permission.READWRITE.

### DIFF
--- a/src/main/java/org/twonote/rgwadmin4j/model/SubUser.java
+++ b/src/main/java/org/twonote/rgwadmin4j/model/SubUser.java
@@ -77,7 +77,7 @@ public class SubUser {
     @SerializedName("write")
     WRITE,
 
-    @SerializedName("readwrite")
+    @SerializedName("read-write")
     READWRITE,
 
     @SerializedName(


### PR DESCRIPTION
Fix a bug. If a subUser have READWRITE permission, you will get a NULL PERMISSION when you get subUser info. This commit can fix this bug by modify the serializedName of Permission.READWRITE.